### PR TITLE
feat: add context support

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -41,6 +41,7 @@ func Exec(cmd Function) {
 	ExecContext(context.Background(), cmd)
 }
 
+// ExecContext calls Exec but with a specified context.Context.
 func ExecContext(ctx context.Context, cmd Function) {
 	name := filepath.Base(os.Args[0])
 	args := os.Args[1:]
@@ -70,6 +71,7 @@ func Call(cmd Function, args ...string) int {
 	return CallContext(context.TODO(), cmd, args...)
 }
 
+// CallContext calls Call but with a specified context.Context.
 func CallContext(ctx context.Context, cmd Function, args ...string) int {
 	prefix := strings.ToUpper(snakecase(nameOf(cmd)))
 

--- a/cli.go
+++ b/cli.go
@@ -38,7 +38,7 @@ type Function interface {
 //
 // The Exec function never returns.
 func Exec(cmd Function) {
-	ExecContext(context.Background(), cmd)
+	ExecContext(context.TODO(), cmd)
 }
 
 // ExecContext calls Exec but with a specified context.Context.

--- a/cli.go
+++ b/cli.go
@@ -2,6 +2,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -20,7 +21,7 @@ var Err io.Writer = os.Stderr
 // Functions returns a status code intended to be the exit code of the program
 // that called them as well as a non-nil error if the function call failed.
 type Function interface {
-	Call(args, env []string) (int, error)
+	Call(ctx context.Context, args, env []string) (int, error)
 }
 
 // Exec delegate the program execution to cmd, then exits with the code returned
@@ -36,11 +37,11 @@ type Function interface {
 //	}
 //
 // The Exec function never returns.
-func Exec(cmd Function) {
+func Exec(ctx context.Context, cmd Function) {
 	name := filepath.Base(os.Args[0])
 	args := os.Args[1:]
 	prog := NamedCommand(name, cmd)
-	os.Exit(Call(prog, args...))
+	os.Exit(Call(ctx, prog, args...))
 }
 
 // Call calls cmd with args and environment variables prefixed with the
@@ -61,10 +62,10 @@ func Exec(cmd Function) {
 //		// ...
 //	}
 //
-func Call(cmd Function, args ...string) int {
+func Call(ctx context.Context, cmd Function, args ...string) int {
 	prefix := strings.ToUpper(snakecase(nameOf(cmd)))
 
-	code, err := cmd.Call(args, environ(prefix))
+	code, err := cmd.Call(ctx, args, environ(prefix))
 
 	switch err.(type) {
 	case nil:

--- a/cli.go
+++ b/cli.go
@@ -37,11 +37,15 @@ type Function interface {
 //	}
 //
 // The Exec function never returns.
-func Exec(ctx context.Context, cmd Function) {
+func Exec(cmd Function) {
+	ExecContext(context.Background(), cmd)
+}
+
+func ExecContext(ctx context.Context, cmd Function) {
 	name := filepath.Base(os.Args[0])
 	args := os.Args[1:]
 	prog := NamedCommand(name, cmd)
-	os.Exit(Call(ctx, prog, args...))
+	os.Exit(CallContext(ctx, prog, args...))
 }
 
 // Call calls cmd with args and environment variables prefixed with the
@@ -62,7 +66,11 @@ func Exec(ctx context.Context, cmd Function) {
 //		// ...
 //	}
 //
-func Call(ctx context.Context, cmd Function, args ...string) int {
+func Call(cmd Function, args ...string) int {
+	return CallContext(context.TODO(), cmd, args...)
+}
+
+func CallContext(ctx context.Context, cmd Function, args ...string) int {
 	prefix := strings.ToUpper(snakecase(nameOf(cmd)))
 
 	code, err := cmd.Call(ctx, args, environ(prefix))

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -9,6 +10,8 @@ import (
 )
 
 func ExampleCommand_bool() {
+	ctx := context.TODO()
+
 	type config struct {
 		Bool bool `flag:"-f,--flag"`
 	}
@@ -17,13 +20,13 @@ func ExampleCommand_bool() {
 		fmt.Println(config.Bool)
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f")
-	cli.Call(cmd, "--flag")
-	cli.Call(cmd, "-f=false")
-	cli.Call(cmd, "--flag=false")
-	cli.Call(cmd, "-f=true")
-	cli.Call(cmd, "--flag=true")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f")
+	cli.Call(ctx, cmd, "--flag")
+	cli.Call(ctx, cmd, "-f=false")
+	cli.Call(ctx, cmd, "--flag=false")
+	cli.Call(ctx, cmd, "-f=true")
+	cli.Call(ctx, cmd, "--flag=true")
 
 	// Output:
 	// false
@@ -36,6 +39,8 @@ func ExampleCommand_bool() {
 }
 
 func ExampleCommand_int() {
+	ctx := context.TODO()
+
 	type config struct {
 		Int int `flag:"-f,--flag" default:"-"`
 	}
@@ -44,11 +49,11 @@ func ExampleCommand_int() {
 		fmt.Println(config.Int)
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f=1")
-	cli.Call(cmd, "--flag=2")
-	cli.Call(cmd, "-f", "3")
-	cli.Call(cmd, "--flag", "4")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f=1")
+	cli.Call(ctx, cmd, "--flag=2")
+	cli.Call(ctx, cmd, "-f", "3")
+	cli.Call(ctx, cmd, "--flag", "4")
 
 	// Output:
 	// 0
@@ -59,6 +64,8 @@ func ExampleCommand_int() {
 }
 
 func ExampleCommand_uint() {
+	ctx := context.TODO()
+
 	type config struct {
 		Uint uint `flag:"-f,--flag" default:"-"`
 	}
@@ -67,11 +74,11 @@ func ExampleCommand_uint() {
 		fmt.Println(config.Uint)
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f=1")
-	cli.Call(cmd, "--flag=2")
-	cli.Call(cmd, "-f", "3")
-	cli.Call(cmd, "--flag", "4")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f=1")
+	cli.Call(ctx, cmd, "--flag=2")
+	cli.Call(ctx, cmd, "-f", "3")
+	cli.Call(ctx, cmd, "--flag", "4")
 
 	// Output:
 	// 0
@@ -82,6 +89,8 @@ func ExampleCommand_uint() {
 }
 
 func ExampleCommand_float() {
+	ctx := context.TODO()
+
 	type config struct {
 		Float float64 `flag:"-f,--flag" default:"-"`
 	}
@@ -90,11 +99,11 @@ func ExampleCommand_float() {
 		fmt.Println(config.Float)
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f=1")
-	cli.Call(cmd, "--flag=2")
-	cli.Call(cmd, "-f", "3")
-	cli.Call(cmd, "--flag", "4")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f=1")
+	cli.Call(ctx, cmd, "--flag=2")
+	cli.Call(ctx, cmd, "-f", "3")
+	cli.Call(ctx, cmd, "--flag", "4")
 
 	// Output:
 	// 0
@@ -105,6 +114,8 @@ func ExampleCommand_float() {
 }
 
 func ExampleCommand_string() {
+	ctx := context.TODO()
+
 	type config struct {
 		String string `flag:"-f,--flag" default:"-"`
 	}
@@ -113,17 +124,17 @@ func ExampleCommand_string() {
 		fmt.Println(config.String)
 	})
 
-	cli.Call(cmd)
+	cli.Call(ctx, cmd)
 
-	cli.Call(cmd, "-f=")
-	cli.Call(cmd, "-f=short")
-	cli.Call(cmd, "-f", "")
-	cli.Call(cmd, "-f", "hello world")
+	cli.Call(ctx, cmd, "-f=")
+	cli.Call(ctx, cmd, "-f=short")
+	cli.Call(ctx, cmd, "-f", "")
+	cli.Call(ctx, cmd, "-f", "hello world")
 
-	cli.Call(cmd, "--flag=")
-	cli.Call(cmd, "--flag=long")
-	cli.Call(cmd, "--flag", "")
-	cli.Call(cmd, "--flag", "hello world")
+	cli.Call(ctx, cmd, "--flag=")
+	cli.Call(ctx, cmd, "--flag=long")
+	cli.Call(ctx, cmd, "--flag", "")
+	cli.Call(ctx, cmd, "--flag", "hello world")
 
 	// Output:
 	//
@@ -138,6 +149,8 @@ func ExampleCommand_string() {
 }
 
 func ExampleCommand_duration() {
+	ctx := context.TODO()
+
 	type config struct {
 		Duration time.Duration `flag:"-f,--flag" default:"-"`
 	}
@@ -146,11 +159,11 @@ func ExampleCommand_duration() {
 		fmt.Println(config.Duration)
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f=1ms")
-	cli.Call(cmd, "--flag=2s")
-	cli.Call(cmd, "-f", "3m")
-	cli.Call(cmd, "--flag", "4h")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f=1ms")
+	cli.Call(ctx, cmd, "--flag=2s")
+	cli.Call(ctx, cmd, "-f", "3m")
+	cli.Call(ctx, cmd, "--flag", "4h")
 
 	// Output:
 	// 0s
@@ -161,6 +174,8 @@ func ExampleCommand_duration() {
 }
 
 func ExampleCommand_time() {
+	ctx := context.TODO()
+
 	type config struct {
 		Time time.Time `flag:"-f,--flag" default:"-"`
 	}
@@ -169,11 +184,11 @@ func ExampleCommand_time() {
 		fmt.Println(config.Time.Unix())
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f=Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(cmd, "--flag=Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(cmd, "-f", "Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f=Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(ctx, cmd, "--flag=Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(ctx, cmd, "-f", "Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(ctx, cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 PST")
 
 	// Output:
 	//-62135596800
@@ -184,6 +199,8 @@ func ExampleCommand_time() {
 }
 
 func ExampleCommand_slice() {
+	ctx := context.TODO()
+
 	type config struct {
 		// Slice types in the configuration struct means the flag can be
 		// passed multiple times.
@@ -194,8 +211,8 @@ func ExampleCommand_slice() {
 		fmt.Println(config.Input)
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "-f=file1", "--flag=file2", "--flag", "file3")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "-f=file1", "--flag=file2", "--flag", "file3")
 
 	// Output:
 	// []
@@ -210,6 +227,8 @@ func (u *unmarshaler) UnmarshalText(b []byte) error {
 }
 
 func ExampleCommand_textUnmarshaler() {
+	ctx := context.TODO()
+
 	type config struct {
 		Input unmarshaler `flag:"-f,--flag" default:"-"`
 	}
@@ -218,8 +237,8 @@ func ExampleCommand_textUnmarshaler() {
 		fmt.Println(string(config.Input))
 	})
 
-	cli.Call(cmd)
-	cli.Call(cmd, "--flag", "hello world")
+	cli.Call(ctx, cmd)
+	cli.Call(ctx, cmd, "--flag", "hello world")
 
 	// Output:
 	//
@@ -227,6 +246,8 @@ func ExampleCommand_textUnmarshaler() {
 }
 
 func ExampleCommand_default() {
+	ctx := context.TODO()
+
 	type config struct {
 		Path string `flag:"-p,--path" default:"file.txt" env:"-"`
 	}
@@ -235,11 +256,13 @@ func ExampleCommand_default() {
 		fmt.Println(config.Path)
 	})
 
-	cli.Call(cmd)
+	cli.Call(ctx, cmd)
 	// Output: file.txt
 }
 
 func ExampleCommand_required() {
+	ctx := context.TODO()
+
 	type config struct {
 		Path string `flag:"-p,--path" env:"-"`
 	}
@@ -249,7 +272,7 @@ func ExampleCommand_required() {
 	})
 
 	cli.Err = os.Stdout
-	cli.Call(cmd)
+	cli.Call(ctx, cmd)
 	// Output:
 	// Usage:
 	//   [options]
@@ -263,6 +286,8 @@ func ExampleCommand_required() {
 }
 
 func ExampleCommand_environment() {
+	ctx := context.TODO()
+
 	type config struct {
 		String string `flag:"-f,--flag" default:"-"`
 	}
@@ -273,44 +298,89 @@ func ExampleCommand_environment() {
 
 	os.Setenv("FLAG", "hello world")
 	cli.Err = os.Stdout
-	cli.Call(cmd)
+	cli.Call(ctx, cmd)
 	// Output: hello world
 }
 
 func ExampleCommand_positional_arguments() {
+	ctx := context.TODO()
+
 	type config struct{}
 
 	cmd := cli.Command(func(config config, x, y int) {
 		fmt.Println(x, y)
 	})
 
-	cli.Call(cmd, "10", "42")
+	cli.Call(ctx, cmd, "10", "42")
 	// Output: 10 42
 }
 
 func ExampleCommand_positional_arguments_slice() {
+	ctx := context.TODO()
+
 	type config struct{}
 
 	cmd := cli.Command(func(config config, paths []string) {
 		fmt.Println(paths)
 	})
 
-	cli.Call(cmd, "file1.txt", "file2.txt", "file3.txt")
+	cli.Call(ctx, cmd, "file1.txt", "file2.txt", "file3.txt")
 	// Output: [file1.txt file2.txt file3.txt]
 }
 
 func ExampleCommand_with_sub_command() {
+	ctx := context.TODO()
+
 	type config struct{}
 
 	cmd := cli.Command(func(config config, sub ...string) {
 		fmt.Println(sub)
 	})
 
-	cli.Call(cmd, "--", "curl", "https://segment.com")
+	cli.Call(ctx, cmd, "--", "curl", "https://segment.com")
 	// Output: [curl https://segment.com]
 }
 
+func ExampleCommand_context() {
+	ctx := context.TODO()
+
+	cmd := cli.Command(func(ctx context.Context) {
+		fmt.Println("hello world")
+	})
+
+	cli.Call(ctx, cmd)
+	// Output: hello world
+}
+
+func ExampleCommand_context_config() {
+	ctx := context.TODO()
+
+	type config struct{}
+
+	cmd := cli.Command(func(ctx context.Context, config config) {
+		fmt.Println("hello world")
+	})
+
+	cli.Call(ctx, cmd)
+	// Output: hello world
+}
+
+func ExampleCommand_context_args() {
+	ctx := context.TODO()
+
+	type config struct{}
+
+	cmd := cli.Command(func(ctx context.Context, config config, args []string) {
+		fmt.Println(args)
+	})
+
+	cli.Call(ctx, cmd, "hello", "world")
+	// Output: [hello world]
+}
+
 func ExampleCommandSet() {
+	ctx := context.TODO()
+
 	help := cli.Command(func() {
 		fmt.Println("help")
 	})
@@ -331,9 +401,9 @@ func ExampleCommandSet() {
 		},
 	}
 
-	cli.Call(cmd, "help")
-	cli.Call(cmd, "do", "this")
-	cli.Call(cmd, "do", "that")
+	cli.Call(ctx, cmd, "help")
+	cli.Call(ctx, cmd, "do", "this")
+	cli.Call(ctx, cmd, "do", "that")
 
 	// Output:
 	// help
@@ -342,6 +412,8 @@ func ExampleCommandSet() {
 }
 
 func ExampleCommand_help() {
+	ctx := context.TODO()
+
 	type config struct {
 		Path  string `flag:"--path"     help:"Path to some file" default:"file" env:"-"`
 		Debug bool   `flag:"-d,--debug" help:"Enable debug mode"`
@@ -354,7 +426,7 @@ func ExampleCommand_help() {
 	}
 
 	cli.Err = os.Stdout
-	cli.Call(cmd, "do", "-h")
+	cli.Call(ctx, cmd, "do", "-h")
 
 	// Output:
 	// Usage:
@@ -367,6 +439,8 @@ func ExampleCommand_help() {
 }
 
 func ExampleCommand_usage() {
+	ctx := context.TODO()
+
 	type config struct {
 		Count int  `flag:"-n"         help:"Number of things"  default:"1"`
 		Debug bool `flag:"-d,--debug" help:"Enable debug mode"`
@@ -379,7 +453,7 @@ func ExampleCommand_usage() {
 	}
 
 	cli.Err = os.Stdout
-	cli.Call(cmd, "do", "-n", "abc")
+	cli.Call(ctx, cmd, "do", "-n", "abc")
 
 	// Output:
 	// Usage:
@@ -395,6 +469,8 @@ func ExampleCommand_usage() {
 }
 
 func ExampleCommandSet_help() {
+	ctx := context.TODO()
+
 	type thisConfig struct {
 		_     struct{} `help:"Call this command"`
 		Path  string   `flag:"-p,--path"  help:"Path to some file" default:"file" env:"-"`
@@ -419,7 +495,7 @@ func ExampleCommandSet_help() {
 	}
 
 	cli.Err = os.Stdout
-	cli.Call(cmd, "do", "--help")
+	cli.Call(ctx, cmd, "do", "--help")
 
 	// Output:
 	// Usage:

--- a/cli_test.go
+++ b/cli_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func ExampleCommand_bool() {
-	ctx := context.TODO()
-
 	type config struct {
 		Bool bool `flag:"-f,--flag"`
 	}
@@ -20,13 +18,13 @@ func ExampleCommand_bool() {
 		fmt.Println(config.Bool)
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f")
-	cli.Call(ctx, cmd, "--flag")
-	cli.Call(ctx, cmd, "-f=false")
-	cli.Call(ctx, cmd, "--flag=false")
-	cli.Call(ctx, cmd, "-f=true")
-	cli.Call(ctx, cmd, "--flag=true")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f")
+	cli.Call(cmd, "--flag")
+	cli.Call(cmd, "-f=false")
+	cli.Call(cmd, "--flag=false")
+	cli.Call(cmd, "-f=true")
+	cli.Call(cmd, "--flag=true")
 
 	// Output:
 	// false
@@ -39,8 +37,6 @@ func ExampleCommand_bool() {
 }
 
 func ExampleCommand_int() {
-	ctx := context.TODO()
-
 	type config struct {
 		Int int `flag:"-f,--flag" default:"-"`
 	}
@@ -49,11 +45,11 @@ func ExampleCommand_int() {
 		fmt.Println(config.Int)
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f=1")
-	cli.Call(ctx, cmd, "--flag=2")
-	cli.Call(ctx, cmd, "-f", "3")
-	cli.Call(ctx, cmd, "--flag", "4")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f=1")
+	cli.Call(cmd, "--flag=2")
+	cli.Call(cmd, "-f", "3")
+	cli.Call(cmd, "--flag", "4")
 
 	// Output:
 	// 0
@@ -64,8 +60,6 @@ func ExampleCommand_int() {
 }
 
 func ExampleCommand_uint() {
-	ctx := context.TODO()
-
 	type config struct {
 		Uint uint `flag:"-f,--flag" default:"-"`
 	}
@@ -74,11 +68,11 @@ func ExampleCommand_uint() {
 		fmt.Println(config.Uint)
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f=1")
-	cli.Call(ctx, cmd, "--flag=2")
-	cli.Call(ctx, cmd, "-f", "3")
-	cli.Call(ctx, cmd, "--flag", "4")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f=1")
+	cli.Call(cmd, "--flag=2")
+	cli.Call(cmd, "-f", "3")
+	cli.Call(cmd, "--flag", "4")
 
 	// Output:
 	// 0
@@ -89,8 +83,6 @@ func ExampleCommand_uint() {
 }
 
 func ExampleCommand_float() {
-	ctx := context.TODO()
-
 	type config struct {
 		Float float64 `flag:"-f,--flag" default:"-"`
 	}
@@ -99,11 +91,11 @@ func ExampleCommand_float() {
 		fmt.Println(config.Float)
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f=1")
-	cli.Call(ctx, cmd, "--flag=2")
-	cli.Call(ctx, cmd, "-f", "3")
-	cli.Call(ctx, cmd, "--flag", "4")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f=1")
+	cli.Call(cmd, "--flag=2")
+	cli.Call(cmd, "-f", "3")
+	cli.Call(cmd, "--flag", "4")
 
 	// Output:
 	// 0
@@ -114,8 +106,6 @@ func ExampleCommand_float() {
 }
 
 func ExampleCommand_string() {
-	ctx := context.TODO()
-
 	type config struct {
 		String string `flag:"-f,--flag" default:"-"`
 	}
@@ -124,17 +114,17 @@ func ExampleCommand_string() {
 		fmt.Println(config.String)
 	})
 
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 
-	cli.Call(ctx, cmd, "-f=")
-	cli.Call(ctx, cmd, "-f=short")
-	cli.Call(ctx, cmd, "-f", "")
-	cli.Call(ctx, cmd, "-f", "hello world")
+	cli.Call(cmd, "-f=")
+	cli.Call(cmd, "-f=short")
+	cli.Call(cmd, "-f", "")
+	cli.Call(cmd, "-f", "hello world")
 
-	cli.Call(ctx, cmd, "--flag=")
-	cli.Call(ctx, cmd, "--flag=long")
-	cli.Call(ctx, cmd, "--flag", "")
-	cli.Call(ctx, cmd, "--flag", "hello world")
+	cli.Call(cmd, "--flag=")
+	cli.Call(cmd, "--flag=long")
+	cli.Call(cmd, "--flag", "")
+	cli.Call(cmd, "--flag", "hello world")
 
 	// Output:
 	//
@@ -149,8 +139,6 @@ func ExampleCommand_string() {
 }
 
 func ExampleCommand_duration() {
-	ctx := context.TODO()
-
 	type config struct {
 		Duration time.Duration `flag:"-f,--flag" default:"-"`
 	}
@@ -159,11 +147,11 @@ func ExampleCommand_duration() {
 		fmt.Println(config.Duration)
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f=1ms")
-	cli.Call(ctx, cmd, "--flag=2s")
-	cli.Call(ctx, cmd, "-f", "3m")
-	cli.Call(ctx, cmd, "--flag", "4h")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f=1ms")
+	cli.Call(cmd, "--flag=2s")
+	cli.Call(cmd, "-f", "3m")
+	cli.Call(cmd, "--flag", "4h")
 
 	// Output:
 	// 0s
@@ -174,8 +162,6 @@ func ExampleCommand_duration() {
 }
 
 func ExampleCommand_time() {
-	ctx := context.TODO()
-
 	type config struct {
 		Time time.Time `flag:"-f,--flag" default:"-"`
 	}
@@ -184,11 +170,11 @@ func ExampleCommand_time() {
 		fmt.Println(config.Time.Unix())
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f=Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(ctx, cmd, "--flag=Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(ctx, cmd, "-f", "Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(ctx, cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f=Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(cmd, "--flag=Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(cmd, "-f", "Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 PST")
 
 	// Output:
 	//-62135596800
@@ -199,8 +185,6 @@ func ExampleCommand_time() {
 }
 
 func ExampleCommand_slice() {
-	ctx := context.TODO()
-
 	type config struct {
 		// Slice types in the configuration struct means the flag can be
 		// passed multiple times.
@@ -211,8 +195,8 @@ func ExampleCommand_slice() {
 		fmt.Println(config.Input)
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "-f=file1", "--flag=file2", "--flag", "file3")
+	cli.Call(cmd)
+	cli.Call(cmd, "-f=file1", "--flag=file2", "--flag", "file3")
 
 	// Output:
 	// []
@@ -227,8 +211,6 @@ func (u *unmarshaler) UnmarshalText(b []byte) error {
 }
 
 func ExampleCommand_textUnmarshaler() {
-	ctx := context.TODO()
-
 	type config struct {
 		Input unmarshaler `flag:"-f,--flag" default:"-"`
 	}
@@ -237,8 +219,8 @@ func ExampleCommand_textUnmarshaler() {
 		fmt.Println(string(config.Input))
 	})
 
-	cli.Call(ctx, cmd)
-	cli.Call(ctx, cmd, "--flag", "hello world")
+	cli.Call(cmd)
+	cli.Call(cmd, "--flag", "hello world")
 
 	// Output:
 	//
@@ -246,8 +228,6 @@ func ExampleCommand_textUnmarshaler() {
 }
 
 func ExampleCommand_default() {
-	ctx := context.TODO()
-
 	type config struct {
 		Path string `flag:"-p,--path" default:"file.txt" env:"-"`
 	}
@@ -256,13 +236,11 @@ func ExampleCommand_default() {
 		fmt.Println(config.Path)
 	})
 
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output: file.txt
 }
 
 func ExampleCommand_required() {
-	ctx := context.TODO()
-
 	type config struct {
 		Path string `flag:"-p,--path" env:"-"`
 	}
@@ -272,7 +250,7 @@ func ExampleCommand_required() {
 	})
 
 	cli.Err = os.Stdout
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output:
 	// Usage:
 	//   [options]
@@ -286,8 +264,6 @@ func ExampleCommand_required() {
 }
 
 func ExampleCommand_environment() {
-	ctx := context.TODO()
-
 	type config struct {
 		String string `flag:"-f,--flag" default:"-"`
 	}
@@ -298,46 +274,40 @@ func ExampleCommand_environment() {
 
 	os.Setenv("FLAG", "hello world")
 	cli.Err = os.Stdout
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output: hello world
 }
 
 func ExampleCommand_positional_arguments() {
-	ctx := context.TODO()
-
 	type config struct{}
 
 	cmd := cli.Command(func(config config, x, y int) {
 		fmt.Println(x, y)
 	})
 
-	cli.Call(ctx, cmd, "10", "42")
+	cli.Call(cmd, "10", "42")
 	// Output: 10 42
 }
 
 func ExampleCommand_positional_arguments_slice() {
-	ctx := context.TODO()
-
 	type config struct{}
 
 	cmd := cli.Command(func(config config, paths []string) {
 		fmt.Println(paths)
 	})
 
-	cli.Call(ctx, cmd, "file1.txt", "file2.txt", "file3.txt")
+	cli.Call(cmd, "file1.txt", "file2.txt", "file3.txt")
 	// Output: [file1.txt file2.txt file3.txt]
 }
 
 func ExampleCommand_with_sub_command() {
-	ctx := context.TODO()
-
 	type config struct{}
 
 	cmd := cli.Command(func(config config, sub ...string) {
 		fmt.Println(sub)
 	})
 
-	cli.Call(ctx, cmd, "--", "curl", "https://segment.com")
+	cli.Call(cmd, "--", "curl", "https://segment.com")
 	// Output: [curl https://segment.com]
 }
 
@@ -348,7 +318,7 @@ func ExampleCommand_context() {
 		fmt.Println("hello world")
 	})
 
-	cli.Call(ctx, cmd)
+	cli.CallContext(ctx, cmd)
 	// Output: hello world
 }
 
@@ -361,7 +331,7 @@ func ExampleCommand_context_config() {
 		fmt.Println("hello world")
 	})
 
-	cli.Call(ctx, cmd)
+	cli.CallContext(ctx, cmd)
 	// Output: hello world
 }
 
@@ -374,13 +344,11 @@ func ExampleCommand_context_args() {
 		fmt.Println(args)
 	})
 
-	cli.Call(ctx, cmd, "hello", "world")
+	cli.CallContext(ctx, cmd, "hello", "world")
 	// Output: [hello world]
 }
 
 func ExampleCommandSet() {
-	ctx := context.TODO()
-
 	help := cli.Command(func() {
 		fmt.Println("help")
 	})
@@ -401,9 +369,9 @@ func ExampleCommandSet() {
 		},
 	}
 
-	cli.Call(ctx, cmd, "help")
-	cli.Call(ctx, cmd, "do", "this")
-	cli.Call(ctx, cmd, "do", "that")
+	cli.Call(cmd, "help")
+	cli.Call(cmd, "do", "this")
+	cli.Call(cmd, "do", "that")
 
 	// Output:
 	// help
@@ -412,8 +380,6 @@ func ExampleCommandSet() {
 }
 
 func ExampleCommand_help() {
-	ctx := context.TODO()
-
 	type config struct {
 		Path  string `flag:"--path"     help:"Path to some file" default:"file" env:"-"`
 		Debug bool   `flag:"-d,--debug" help:"Enable debug mode"`
@@ -426,7 +392,7 @@ func ExampleCommand_help() {
 	}
 
 	cli.Err = os.Stdout
-	cli.Call(ctx, cmd, "do", "-h")
+	cli.Call(cmd, "do", "-h")
 
 	// Output:
 	// Usage:
@@ -439,8 +405,6 @@ func ExampleCommand_help() {
 }
 
 func ExampleCommand_usage() {
-	ctx := context.TODO()
-
 	type config struct {
 		Count int  `flag:"-n"         help:"Number of things"  default:"1"`
 		Debug bool `flag:"-d,--debug" help:"Enable debug mode"`
@@ -453,7 +417,7 @@ func ExampleCommand_usage() {
 	}
 
 	cli.Err = os.Stdout
-	cli.Call(ctx, cmd, "do", "-n", "abc")
+	cli.Call(cmd, "do", "-n", "abc")
 
 	// Output:
 	// Usage:
@@ -469,8 +433,6 @@ func ExampleCommand_usage() {
 }
 
 func ExampleCommandSet_help() {
-	ctx := context.TODO()
-
 	type thisConfig struct {
 		_     struct{} `help:"Call this command"`
 		Path  string   `flag:"-p,--path"  help:"Path to some file" default:"file" env:"-"`
@@ -495,7 +457,7 @@ func ExampleCommandSet_help() {
 	}
 
 	cli.Err = os.Stdout
-	cli.Call(ctx, cmd, "do", "--help")
+	cli.Call(cmd, "do", "--help")
 
 	// Output:
 	// Usage:

--- a/cli_test.go
+++ b/cli_test.go
@@ -312,14 +312,21 @@ func ExampleCommand_with_sub_command() {
 }
 
 func ExampleCommand_context() {
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	cmd := cli.Command(func(ctx context.Context) {
-		fmt.Println("hello world")
+		if ctx == context.TODO() {
+			fmt.Println("context.TODO()")
+		} else {
+			fmt.Println("context.Background()")
+		}
 	})
 
+	cli.Call(cmd)
 	cli.CallContext(ctx, cmd)
-	// Output: hello world
+	// Output:
+	// context.TODO()
+	// context.Background()
 }
 
 func ExampleCommand_context_config() {

--- a/command.go
+++ b/command.go
@@ -122,7 +122,7 @@ func (cmd *CommandFunc) configure() {
 		panic("cli.Command: expected a function as argument but got " + t.String())
 	}
 
-	ctx := reflect.TypeOf((*context.Context)(nil)).Elem()
+	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
 
 	cmd.function = v
 	cmd.variadic = t.IsVariadic()
@@ -132,7 +132,7 @@ func (cmd *CommandFunc) configure() {
 	} else {
 		x := 0
 
-		if f := t.In(x); f.Kind() == reflect.Interface && f.Implements(ctx) {
+		if f := t.In(x); f.Kind() == reflect.Interface && f.Implements(ctxType) {
 			cmd.context = true
 			x++
 		}

--- a/command.go
+++ b/command.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -105,6 +106,7 @@ type CommandFunc struct {
 	options  structDecoder
 	values   []decodeFunc
 	variadic bool
+	context  bool
 	help     string
 }
 
@@ -120,23 +122,35 @@ func (cmd *CommandFunc) configure() {
 		panic("cli.Command: expected a function as argument but got " + t.String())
 	}
 
+	ctx := reflect.TypeOf((*context.Context)(nil)).Elem()
+
 	cmd.function = v
 	cmd.variadic = t.IsVariadic()
 
 	if n := t.NumIn(); n == 0 {
 		cmd.parser, cmd.options, cmd.help = makeStructDecoder(emptyType)
 	} else {
-		if f := t.In(0); f.Kind() == reflect.Struct {
-			cmd.parser, cmd.options, cmd.help = makeStructDecoder(f)
-		} else {
-			panic("cli.Command: expected a struct as first argument but got " + f.String())
+		x := 0
+
+		if f := t.In(x); f.Kind() == reflect.Interface && f.Implements(ctx) {
+			cmd.context = true
+			x++
+		}
+
+		if x < n {
+			if f := t.In(x); f.Kind() == reflect.Struct {
+				cmd.parser, cmd.options, cmd.help = makeStructDecoder(f)
+				x++
+			} else {
+				panic("cli.Command: expected a struct as first argument but got " + f.String())
+			}
 		}
 
 		if cmd.variadic {
 			n--
 		}
 
-		for i := 1; i < n; i++ {
+		for i := x; i < n; i++ {
 			p := t.In(i)
 
 			if p.Kind() == reflect.Slice {
@@ -170,7 +184,7 @@ func (cmd *CommandFunc) configure() {
 // Call satisfies the Function interface.
 //
 // See Command for the full documentation of how the Call method behaves.
-func (cmd *CommandFunc) Call(args, env []string) (int, error) {
+func (cmd *CommandFunc) Call(ctx context.Context, args, env []string) (int, error) {
 	cmd.configure()
 
 	options, values, command, err := cmd.parser.parseCommandLine(args)
@@ -207,29 +221,39 @@ func (cmd *CommandFunc) Call(args, env []string) (int, error) {
 
 	var params []reflect.Value
 
-	if t := cmd.function.Type(); t.NumIn() > 0 {
-		// Configuration options are decoded into the first function parameter.
-		v := reflect.New(t.In(0)).Elem()
-		if err := cmd.options.decode(v, options); err != nil {
-			return 1, err
-		}
-		params = append(params, v)
+	x := 0
 
+	if cmd.context {
+		params = append(params, reflect.ValueOf(ctx))
+		x++
+	}
+
+	if t := cmd.function.Type(); t.NumIn() > 0 {
 		// Positional arguments are decoded into each following function
 		// parameter, until a slice type is encountered which receives all
 		// the remaining values.
 		n := t.NumIn()
 
+		if x < n {
+			// Configuration options are decoded into the first function parameter.
+			v := reflect.New(t.In(x)).Elem()
+			if err := cmd.options.decode(v, options); err != nil {
+				return 1, err
+			}
+			params = append(params, v)
+			x++
+		}
+
 		if cmd.variadic {
 			n--
 		}
 
-		for i := 1; i < n; i++ {
+		for i := x; i < n; i++ {
 			p := t.In(i)
 			v := reflect.New(p).Elem()
 
 			if p.Kind() == reflect.Slice {
-				if err := cmd.values[i-1](v, values); err != nil {
+				if err := cmd.values[i-x](v, values); err != nil {
 					return 1, err
 				}
 				params = append(params, v)
@@ -240,11 +264,11 @@ func (cmd *CommandFunc) Call(args, env []string) (int, error) {
 			if len(values) == 0 {
 				return 1, &Usage{
 					Cmd: cmd,
-					Err: fmt.Errorf("expected %d positional arguments but only %d were given", len(cmd.values), i-1),
+					Err: fmt.Errorf("expected %d positional arguments but only %d were given", len(cmd.values), i-x),
 				}
 			}
 
-			if err := cmd.values[i-1](v, values[:1]); err != nil {
+			if err := cmd.values[i-x](v, values[:1]); err != nil {
 				return 1, err
 			}
 			params = append(params, v)
@@ -464,7 +488,7 @@ type CommandSet map[string]Function
 // and a usage error if the first argument did not match any sub-command.
 //
 // Call satisfies the Function interface.
-func (cmds CommandSet) Call(args, env []string) (int, error) {
+func (cmds CommandSet) Call(ctx context.Context, args, env []string) (int, error) {
 	for _, cmd := range cmds {
 		if c, ok := cmd.(interface{ configure() }); ok {
 			c.configure()
@@ -494,7 +518,7 @@ func (cmds CommandSet) Call(args, env []string) (int, error) {
 
 	cmd := NamedCommand(a, c)
 
-	code, err := cmd.Call(args[1:], env)
+	code, err := cmd.Call(ctx, args[1:], env)
 	switch e := err.(type) {
 	case *Help:
 		e.Cmd = cmd
@@ -546,8 +570,8 @@ type namedCommand struct {
 	cmd  Function
 }
 
-func (c namedCommand) Call(args, env []string) (int, error) {
-	code, err := c.cmd.Call(args, env)
+func (c namedCommand) Call(ctx context.Context, args, env []string) (int, error) {
+	code, err := c.cmd.Call(ctx, args, env)
 	switch e := err.(type) {
 	case *Help:
 		e.Cmd = NamedCommand(c.name, e.Cmd)

--- a/command.go
+++ b/command.go
@@ -226,6 +226,8 @@ func (cmd *CommandFunc) Call(ctx context.Context, args, env []string) (int, erro
 	if cmd.context {
 		params = append(params, reflect.ValueOf(ctx))
 		x++
+	} else if ctx != context.TODO() {
+		panic("mixing usage of context aware and unaware commands")
 	}
 
 	if t := cmd.function.Type(); t.NumIn() > 0 {

--- a/format_test.go
+++ b/format_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"os"
 
 	"github.com/segmentio/cli"
@@ -20,7 +21,9 @@ func ExampleFormat_json() {
 		return nil
 	})
 
-	cli.Call(cmd)
+	ctx := context.TODO()
+
+	cli.Call(ctx, cmd)
 	// Output:
 	// {
 	//   "Message": "Hello World!"
@@ -45,7 +48,9 @@ func ExampleFormat_yaml() {
 		return nil
 	})
 
-	cli.Call(cmd)
+	ctx := context.TODO()
+
+	cli.Call(ctx, cmd)
 	// Output:
 	// value: 1
 	// ---
@@ -67,7 +72,9 @@ func ExampleFormat_text_string() {
 		return nil
 	})
 
-	cli.Call(cmd)
+	ctx := context.TODO()
+
+	cli.Call(ctx, cmd)
 	// Output:
 	// hello
 	// world
@@ -93,7 +100,9 @@ func ExampleFormat_text_struct() {
 		return nil
 	})
 
-	cli.Call(cmd)
+	ctx := context.TODO()
+
+	cli.Call(ctx, cmd)
 	// Output:
 	// ID    NAME  VALUE
 	// 1234  A     1
@@ -129,7 +138,9 @@ func ExampleFormat_text_map() {
 		return nil
 	})
 
-	cli.Call(cmd)
+	ctx := context.TODO()
+
+	cli.Call(ctx, cmd)
 	// Output:
 	// ID    NAME  VALUE
 	// 1234  A     1

--- a/format_test.go
+++ b/format_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"context"
 	"os"
 
 	"github.com/segmentio/cli"
@@ -21,9 +20,7 @@ func ExampleFormat_json() {
 		return nil
 	})
 
-	ctx := context.TODO()
-
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output:
 	// {
 	//   "Message": "Hello World!"
@@ -48,9 +45,7 @@ func ExampleFormat_yaml() {
 		return nil
 	})
 
-	ctx := context.TODO()
-
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output:
 	// value: 1
 	// ---
@@ -72,9 +67,7 @@ func ExampleFormat_text_string() {
 		return nil
 	})
 
-	ctx := context.TODO()
-
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output:
 	// hello
 	// world
@@ -100,9 +93,7 @@ func ExampleFormat_text_struct() {
 		return nil
 	})
 
-	ctx := context.TODO()
-
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output:
 	// ID    NAME  VALUE
 	// 1234  A     1
@@ -138,9 +129,7 @@ func ExampleFormat_text_map() {
 		return nil
 	})
 
-	ctx := context.TODO()
-
-	cli.Call(ctx, cmd)
+	cli.Call(cmd)
 	// Output:
 	// ID    NAME  VALUE
 	// 1234  A     1


### PR DESCRIPTION
This PR adds `context.Context` support to this API. I've added `ExecContext` and `CallContext` top-level methods which accept a context to allow users to opt in to either pattern. Users can optionally include context as the first parameter of their functions and if so they will be provided the top-level context when being invoked.