### PR TITLE
Compare times with Unix epoch in tests

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -166,7 +166,7 @@ func ExampleCommand_time() {
 	}
 
 	cmd := cli.Command(func(config config) {
-		fmt.Println(config.Time.UTC())
+		fmt.Println(config.Time.Unix())
 	})
 
 	cli.Call(cmd)
@@ -176,11 +176,11 @@ func ExampleCommand_time() {
 	cli.Call(cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 PST")
 
 	// Output:
-	// 0001-01-01 00:00:00 +0000 UTC
-	// 2006-01-02 15:04:05 +0000 UTC
-	// 2006-01-02 15:04:05 +0000 UTC
-	// 2006-01-02 15:04:05 +0000 UTC
-	// 2006-01-02 15:04:05 +0000 UTC
+	//-62135596800
+	//1136214245
+	//1136214245
+	//1136214245
+	//1136214245
 }
 
 func ExampleCommand_slice() {

--- a/cli_test.go
+++ b/cli_test.go
@@ -166,7 +166,7 @@ func ExampleCommand_time() {
 	}
 
 	cmd := cli.Command(func(config config) {
-		fmt.Println(config.Time)
+		fmt.Println(config.Time.UTC())
 	})
 
 	cli.Call(cmd)
@@ -177,10 +177,10 @@ func ExampleCommand_time() {
 
 	// Output:
 	// 0001-01-01 00:00:00 +0000 UTC
-	// 2006-01-02 15:04:05 -0800 PST
-	// 2006-01-02 15:04:05 -0800 PST
-	// 2006-01-02 15:04:05 -0800 PST
-	// 2006-01-02 15:04:05 -0800 PST
+	// 2006-01-02 15:04:05 +0000 UTC
+	// 2006-01-02 15:04:05 +0000 UTC
+	// 2006-01-02 15:04:05 +0000 UTC
+	// 2006-01-02 15:04:05 +0000 UTC
 }
 
 func ExampleCommand_slice() {


### PR DESCRIPTION
If times are not compared in a specified timezone, the system's timezone
is used. If tests are ran in a non-PST timezone, output won't match:

```
--- FAIL: ExampleCommand_time (0.00s)
got:
0001-01-01 00:00:00 +0000 UTC
2006-01-02 15:04:05 +0000 PST
2006-01-02 15:04:05 +0000 PST
2006-01-02 15:04:05 +0000 PST
2006-01-02 15:04:05 +0000 PST
want:
0001-01-01 00:00:00 +0000 UTC
2006-01-02 15:04:05 -0800 PST
2006-01-02 15:04:05 -0800 PST
2006-01-02 15:04:05 -0800 PST
2006-01-02 15:04:05 -0800 PST
```

This patch forces the use of unix epoch for comparison.