### PR TITLE
Allow spaces in flag

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -432,3 +432,22 @@ func ExampleCommandSet_help() {
 	// Options:
 	//   -h, --help  Show this help message
 }
+
+func ExampleCommand_spacesInFlag() {
+	type config struct {
+		String string `flag:"-f, --flag" default:"-"`
+	}
+
+	cmd := cli.Command(func(config config) {
+		fmt.Println(config.String)
+	})
+
+	cli.Call(cmd)
+
+	cli.Call(cmd, "-f=short")
+	cli.Call(cmd, "--flag", "hello world")
+
+	// Output:
+	// short
+	// hello world
+}

--- a/decode.go
+++ b/decode.go
@@ -61,6 +61,7 @@ func makeStructDecoder(t reflect.Type) (parser, structDecoder, string) {
 		decoder := makeStructFieldDecoder(field)
 
 		for i, flag := range field.flags {
+			flag = strings.TrimSpace(flag)
 			if _, exists := p.aliases[flag]; exists {
 				panic("repeated flag in configuration struct: " + flag)
 			}
@@ -70,7 +71,7 @@ func makeStructDecoder(t reflect.Type) (parser, structDecoder, string) {
 			}
 
 			if n := len(field.flags) - 1; i < n {
-				p.aliases[flag] = field.flags[n]
+				p.aliases[flag] = strings.TrimSpace(field.flags[n])
 			} else {
 				p.options[flag] = option{boolean: boolean}
 				s[flag] = decoder


### PR DESCRIPTION
This allows you to write

```
flag:"-f, --flag" default:"-"
```

(note the space before `--`)