### PR TITLE
fix: handle embedded structs properly by tracking field indexes

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -496,3 +496,29 @@ func ExampleCommand_spacesInFlag() {
 	// short
 	// hello world
 }
+
+func ExampleCommand_embedded_struct() {
+	type embed struct {
+		AnotherString string `flag:"--another-string" default:"b"`
+	}
+
+	type config struct {
+		String string `flag:"--string" default:"a"`
+		embed
+	}
+
+	cmd := cli.Command(func(config config) {
+		fmt.Println(config.String, config.AnotherString)
+	})
+
+	cli.Call(cmd)
+	cli.Call(cmd, "--string", "A")
+	cli.Call(cmd, "--another-string", "B")
+	cli.Call(cmd, "--string", "A", "--another-string", "B")
+
+	// Output:
+	// a b
+	// A b
+	// a B
+	// A B
+}


### PR DESCRIPTION
Currently, if you embed a struct the handling doesn't seem to happen correctly, but it turns out this is because the tracking of the field index isn't actually tracking the nesting properly. This PR includes a test case by me that demonstrated the problem and the fix by @achille-roussel