### PR TITLE
output lists

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -480,6 +480,43 @@ func ExampleCommandSet_help() {
 	//   -h, --help  Show this help message
 }
 
+func ExampleCommandSet_help2() {
+	type thisConfig struct {
+		_     struct{} `help:"Call this command"`
+		Path  string   `flag:"-p,--path"  help:"Path to some file" default:"file" env:"-"`
+		Debug bool     `flag:"-d,--debug" help:"Enable debug mode"`
+	}
+
+	type thatConfig struct {
+		_     struct{} `help:"Call that command"`
+		Count int      `flag:"-n"         help:"Number of things"  default:"1"`
+		Debug bool     `flag:"-d,--debug" help:"Enable debug mode"`
+	}
+
+	cmd := cli.CommandSet{
+		"do": cli.CommandSet{
+			"this": cli.Command(func(config thisConfig) {
+				// ...
+			}),
+			"that": cli.Command(func(config thatConfig) {
+				// ...
+			}),
+		},
+	}
+
+	cli.Err = os.Stdout
+	cli.Call(cmd, "do", "this", "-h")
+
+	// Output:
+	// Usage:
+	//   do this [options]
+	//
+	// Options:
+	//   -d, --debug        Enable debug mode
+	//   -h, --help         Show this help message
+	//   -p, --path string  Path to some file (default: file)
+}
+
 func ExampleCommand_spacesInFlag() {
 	type config struct {
 		String string `flag:"-f, --flag" default:"-"`

--- a/format.go
+++ b/format.go
@@ -76,6 +76,7 @@ func (p *jsonFormat) Flush() {
 	e := json.NewEncoder(p.writer)
 	e.SetIndent("", "  ")
 	e.Encode(p.values)
+	p.values = nil
 }
 
 type yamlFormat struct {
@@ -105,6 +106,7 @@ func (p *yamlFormat) Flush() {
 	e.SetIndent(2)
 	e.Encode(p.values)
 	e.Close()
+	p.values = nil
 }
 
 type textFormat struct {

--- a/format.go
+++ b/format.go
@@ -98,22 +98,20 @@ func newTextFormat(w io.Writer) *textFormat {
 }
 
 func (p *textFormat) Print(x interface{}) {
-	v := reflect.ValueOf(x)
-
 	switch x.(type) {
 	case encoding.TextMarshaler, fmt.Formatter, fmt.Stringer, error:
 		p.print(x)
 		return
 	}
-
-	switch v.Kind() {
+	switch v := reflect.ValueOf(x); v.Kind() {
 	case reflect.Struct:
 		p.printStruct(v)
+	case reflect.Slice:
+		p.printSlice(v)
 	case reflect.Map:
 		p.printMap(v)
 	default:
 		p.print(x)
-		return
 	}
 }
 
@@ -145,6 +143,12 @@ func (p *textFormat) printStruct(v reflect.Value) {
 	})
 
 	io.WriteString(&p.tw, "\n")
+}
+
+func (p *textFormat) printSlice(v reflect.Value) {
+	for i, n := 0, v.Len(); i < n; i++ {
+		p.Print(v.Index(i).Interface())
+	}
 }
 
 func (p *textFormat) printMap(v reflect.Value) {

--- a/format_test.go
+++ b/format_test.go
@@ -22,11 +22,9 @@ func ExampleFormat_json() {
 
 	cli.Call(cmd)
 	// Output:
-	// [
-	//   {
-	//     "Message": "Hello World!"
-	//   }
-	// ]
+	// {
+	//   "Message": "Hello World!"
+	// }
 }
 
 func ExampleFormat_yaml() {
@@ -49,9 +47,11 @@ func ExampleFormat_yaml() {
 
 	cli.Call(cmd)
 	// Output:
-	// - value: 1
-	// - value: 2
-	// - value: 3
+	// value: 1
+	// ---
+	// value: 2
+	// ---
+	// value: 3
 }
 
 func ExampleFormat_text_string() {
@@ -135,4 +135,52 @@ func ExampleFormat_text_map() {
 	// 1234  A     1
 	// 5678  B     2
 	// 9012  C     3
+}
+
+func ExampleFormatList_json() {
+	cmd := cli.Command(func() error {
+		p, err := cli.FormatList("json", os.Stdout)
+		if err != nil {
+			return err
+		}
+		defer p.Flush()
+
+		p.Print(struct {
+			Message string
+		}{"Hello World!"})
+		return nil
+	})
+
+	cli.Call(cmd)
+	// Output:
+	// [
+	//   {
+	//     "Message": "Hello World!"
+	//   }
+	// ]
+}
+
+func ExampleFormatList_yaml() {
+	cmd := cli.Command(func() error {
+		p, err := cli.FormatList("yaml", os.Stdout)
+		if err != nil {
+			return err
+		}
+		defer p.Flush()
+
+		type output struct {
+			Value int `json:"value"`
+		}
+
+		p.Print(output{1})
+		p.Print(output{2})
+		p.Print(output{3})
+		return nil
+	})
+
+	cli.Call(cmd)
+	// Output:
+	// - value: 1
+	// - value: 2
+	// - value: 3
 }

--- a/format_test.go
+++ b/format_test.go
@@ -22,9 +22,11 @@ func ExampleFormat_json() {
 
 	cli.Call(cmd)
 	// Output:
-	// {
-	//   "Message": "Hello World!"
-	// }
+	// [
+	//   {
+	//     "Message": "Hello World!"
+	//   }
+	// ]
 }
 
 func ExampleFormat_yaml() {
@@ -47,11 +49,9 @@ func ExampleFormat_yaml() {
 
 	cli.Call(cmd)
 	// Output:
-	// value: 1
-	// ---
-	// value: 2
-	// ---
-	// value: 3
+	// - value: 1
+	// - value: 2
+	// - value: 3
 }
 
 func ExampleFormat_text_string() {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/segmentio/cli
 
 go 1.13
 
-require gopkg.in/yaml.v2 v2.2.2
+require gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2 h1:XZx7nhd5GMaZpmDaEHFVafUZC7ya0fuo7cSJ3UCKYmM=
+gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
I'd like to change the behavior of the printers to output lists when formatting to JSON or YAML. The previous behavior was to output sequences of objects, but that means the full output was not valid JSON.

Let me know if you have concerns about this change.