### PR TITLE
make human package types implement fmt.Formatter interface

### DIFF
--- a/human/bytes_test.go
+++ b/human/bytes_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
@@ -49,31 +50,37 @@ func TestBytesParse(t *testing.T) {
 func TestBytesFormat(t *testing.T) {
 	for _, test := range []struct {
 		in  Bytes
+		fmt string
 		out string
 	}{
-		{out: "0", in: 0},
-		{out: "2", in: 2},
+		{fmt: "%v", out: "0", in: 0},
+		{fmt: "%v", out: "2", in: 2},
 
-		{out: "1.95Ki", in: 2 * KB},
-		{out: "1.91Mi", in: 2 * MB},
-		{out: "1.86Gi", in: 2 * GB},
-		{out: "1.82Ti", in: 2 * TB},
-		{out: "1.78Pi", in: 2 * PB},
+		{fmt: "%v", out: "1.95Ki", in: 2 * KB},
+		{fmt: "%v", out: "1.91Mi", in: 2 * MB},
+		{fmt: "%v", out: "1.86Gi", in: 2 * GB},
+		{fmt: "%v", out: "1.82Ti", in: 2 * TB},
+		{fmt: "%v", out: "1.78Pi", in: 2 * PB},
 
-		{out: "2Ki", in: 2 * KiB},
-		{out: "2Mi", in: 2 * MiB},
-		{out: "2Gi", in: 2 * GiB},
-		{out: "2Ti", in: 2 * TiB},
-		{out: "2Pi", in: 2 * PiB},
+		{fmt: "%v", out: "2Ki", in: 2 * KiB},
+		{fmt: "%v", out: "2Mi", in: 2 * MiB},
+		{fmt: "%v", out: "2Gi", in: 2 * GiB},
+		{fmt: "%v", out: "2Ti", in: 2 * TiB},
+		{fmt: "%v", out: "2Pi", in: 2 * PiB},
 
-		{out: "1.21Ki", in: 1234},
-		{out: "1.18Mi", in: 1234 * KB},
+		{fmt: "%v", out: "1.21Ki", in: 1234},
+		{fmt: "%v", out: "1.18Mi", in: 1234 * KB},
 
-		{out: "1.5Ki", in: 1*KiB + 512},
-		{out: "1.5Mi", in: 1*MiB + 512*KiB},
+		{fmt: "%v", out: "1.5Ki", in: 1*KiB + 512},
+		{fmt: "%v", out: "1.5Mi", in: 1*MiB + 512*KiB},
+
+		{fmt: "%d", out: "123456789", in: 123456789},
+		{fmt: "%b", out: "123MB", in: 123456789},
+		{fmt: "%s", out: "118Mi", in: 123456789},
+		{fmt: "%#v", out: "human.Bytes(123456789)", in: 123456789},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := test.in.String(); s != test.out {
+			if s := fmt.Sprintf(test.fmt, test.in); s != test.out {
 				t.Error("formatted bytes mismatch:", s, "!=", test.out)
 			}
 		})

--- a/human/count_test.go
+++ b/human/count_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
@@ -31,14 +32,19 @@ func TestCountParse(t *testing.T) {
 func TestCountFormat(t *testing.T) {
 	for _, test := range []struct {
 		in  Count
+		fmt string
 		out string
 	}{
-		{in: 0, out: "0"},
-		{in: 1234, out: "1234"},
-		{in: 10234, out: "10.2K"},
+		{in: 0, fmt: "%v", out: "0"},
+		{in: 1234, fmt: "%v", out: "1234"},
+		{in: 10234, fmt: "%v", out: "10.2K"},
+		{in: 123456789, fmt: "%d", out: "123456789"},
+		{in: 1234.56789, fmt: "%f", out: "1234.56789"},
+		{in: 123456789, fmt: "%s", out: "123M"},
+		{in: 123456789, fmt: "%#v", out: "human.Count(1.23456789e+08)"},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := test.in.String(); s != test.out {
+			if s := fmt.Sprintf(test.fmt, test.in); s != test.out {
 				t.Error("formatted count mismatch:", s, "!=", test.out)
 			}
 		})

--- a/human/duration.go
+++ b/human/duration.go
@@ -326,7 +326,7 @@ func (d *Duration) UnmarshalYAML(y *yaml.Node) error {
 }
 
 func (d Duration) MarshalText() ([]byte, error) {
-	return []byte(d.String()), nil
+	return []byte(d.Text(time.Now())), nil
 }
 
 func (d *Duration) UnmarshalText(b []byte) error {

--- a/human/duration_test.go
+++ b/human/duration_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
@@ -56,28 +57,35 @@ func TestDurationParse(t *testing.T) {
 func TestDurationFormat(t *testing.T) {
 	for _, test := range []struct {
 		in  Duration
+		fmt string
 		out string
 	}{
-		{out: "0s", in: 0},
+		{fmt: "%v", out: "0s", in: 0},
 
-		{out: "1ns", in: Nanosecond},
-		{out: "1µs", in: Microsecond},
-		{out: "1ms", in: Millisecond},
-		{out: "1s", in: Second},
-		{out: "1m", in: Minute},
-		{out: "1h", in: Hour},
+		{fmt: "%v", out: "1ns", in: Nanosecond},
+		{fmt: "%v", out: "1µs", in: Microsecond},
+		{fmt: "%v", out: "1ms", in: Millisecond},
+		{fmt: "%v", out: "1s", in: Second},
+		{fmt: "%v", out: "1m", in: Minute},
+		{fmt: "%v", out: "1h", in: Hour},
 
-		{out: "1d", in: 24 * Hour},
-		{out: "2d", in: 48 * Hour},
-		{out: "1w", in: 7 * 24 * Hour},
-		{out: "2w", in: 14 * 24 * Hour},
-		{out: "1mo", in: 33 * 24 * Hour},
-		{out: "2mo", in: 66 * 24 * Hour},
-		{out: "1y", in: 400 * 24 * Hour},
-		{out: "2y", in: 800 * 24 * Hour},
+		{fmt: "%v", out: "1d", in: 24 * Hour},
+		{fmt: "%v", out: "2d", in: 48 * Hour},
+		{fmt: "%v", out: "1w", in: 7 * 24 * Hour},
+		{fmt: "%v", out: "2w", in: 14 * 24 * Hour},
+		{fmt: "%v", out: "1mo", in: 33 * 24 * Hour},
+		{fmt: "%v", out: "2mo", in: 66 * 24 * Hour},
+		{fmt: "%v", out: "1y", in: 400 * 24 * Hour},
+		{fmt: "%v", out: "2y", in: 800 * 24 * Hour},
+
+		{fmt: "%v", out: "1m30s", in: 1*Minute + 30*Second},
+		{fmt: "%+.1v", out: "2 hours", in: 2*Hour + 1*Minute + 30*Second},
+		{fmt: "%+.2v", out: "2 hours 1 minute", in: 2*Hour + 1*Minute + 30*Second},
+		{fmt: "%+.3v", out: "2 hours 1 minute 30 seconds", in: 2*Hour + 1*Minute + 30*Second},
+		{fmt: "%#v", out: "human.Duration(60000000000)", in: 1 * Minute},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := test.in.String(); s != test.out {
+			if s := fmt.Sprintf(test.fmt, test.in); s != test.out {
 				t.Error("duration string mismatch:", s, "!=", test.out)
 			}
 		})

--- a/human/human.go
+++ b/human/human.go
@@ -199,3 +199,11 @@ func ftoa(value, scale float64) string {
 	}
 	return s
 }
+
+func printError(verb rune, typ, val interface{}) string {
+	return fmt.Sprintf("%%!%c(%T=%v)", verb, typ, val)
+}
+
+type formatter func(fmt.State, rune)
+
+func (f formatter) Format(w fmt.State, v rune) { f(w, v) }

--- a/human/number_test.go
+++ b/human/number_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
@@ -32,16 +33,20 @@ func TestNumberParse(t *testing.T) {
 func TestNumberFormat(t *testing.T) {
 	for _, test := range []struct {
 		in  Number
+		fmt string
 		out string
 	}{
-		{in: 0, out: "0"},
-		{in: 1234, out: "1,234"},
-		{in: 1234.567, out: "1,234.567"},
-		{in: 123456.789, out: "123,456.789"},
-		{in: 1234567.89, out: "1,234,567.89"},
+		{in: 0, fmt: "%v", out: "0"},
+		{in: 1234, fmt: "%v", out: "1,234"},
+		{in: 1234.567, fmt: "%v", out: "1,234.567"},
+		{in: 123456.789, fmt: "%v", out: "123,456.789"},
+		{in: 1234567.89, fmt: "%v", out: "1,234,567.89"},
+		{in: 1234567.89, fmt: "%f", out: "1234567.89"},
+		{in: 1234567.89, fmt: "%s", out: "1,234,567.89"},
+		{in: 1234567.89, fmt: "%#v", out: "human.Number(1.23456789e+06)"},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := test.in.String(); s != test.out {
+			if s := fmt.Sprintf(test.fmt, test.in); s != test.out {
 				t.Error("formatted number mismatch:", s, "!=", test.out)
 			}
 		})

--- a/human/rate_test.go
+++ b/human/rate_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
@@ -32,18 +33,21 @@ func TestRateParse(t *testing.T) {
 func TestRateFormat(t *testing.T) {
 	for _, test := range []struct {
 		in   Rate
+		fmt  string
 		out  string
 		unit Duration
 	}{
-		{in: 0, out: "0/s", unit: Second},
-		{in: 1234, out: "1234/s", unit: Second},
-		{in: 10234, out: "10.2K/s", unit: Second},
-		{in: 0.1, out: "100/ms", unit: Millisecond},
-		{in: 604800, out: "1/w", unit: Week},
-		{in: 1512000, out: "2.5/w", unit: Week},
+		{in: 0, fmt: "%v", out: "0/s", unit: Second},
+		{in: 1234, fmt: "%v", out: "1234/s", unit: Second},
+		{in: 10234, fmt: "%v", out: "10.2K/s", unit: Second},
+		{in: 0.1, fmt: "%v", out: "100/ms", unit: Millisecond},
+		{in: 604800, fmt: "%v", out: "1/w", unit: Week},
+		{in: 1512000, fmt: "%v", out: "2.5/w", unit: Week},
+		{in: 25, fmt: "%s", out: "25/s", unit: Second},
+		{in: 25, fmt: "%#v", out: "human.Rate(25)", unit: Second},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := test.in.Text(test.unit); s != test.out {
+			if s := fmt.Sprintf(test.fmt, test.in.Formatter(test.unit)); s != test.out {
 				t.Error("formatted rate mismatch:", s, "!=", test.out)
 			}
 		})

--- a/human/ratio_test.go
+++ b/human/ratio_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	yaml "gopkg.in/yaml.v3"
@@ -34,15 +35,17 @@ func TestRatioParse(t *testing.T) {
 func TestRatioFormat(t *testing.T) {
 	for _, test := range []struct {
 		in  Ratio
+		fmt string
 		out string
 	}{
-		{in: 0, out: "0%"},
-		{in: 0.1234, out: "12.34%"},
-		{in: 1, out: "100%"},
-		{in: 2, out: "200%"},
+		{in: 0, fmt: "%v", out: "0%"},
+		{in: 0.1234, fmt: "%v", out: "12.34%"},
+		{in: 1, fmt: "%v", out: "100%"},
+		{in: 2, fmt: "%v", out: "200%"},
+		{in: 0.234, fmt: "%#v", out: "human.Ratio(0.234)"},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := test.in.String(); s != test.out {
+			if s := fmt.Sprintf(test.fmt, test.in); s != test.out {
 				t.Error("formatted ratio mismatch:", s, "!=", test.out)
 			}
 		})

--- a/human/time.go
+++ b/human/time.go
@@ -175,7 +175,7 @@ func (t *Time) UnmarshalYAML(y *yaml.Node) error {
 }
 
 func (t Time) MarshalText() ([]byte, error) {
-	return []byte(t.String()), nil
+	return []byte(t.Text(time.Now())), nil
 }
 
 func (t *Time) UnmarshalText(b []byte) error {

--- a/human/time_test.go
+++ b/human/time_test.go
@@ -2,6 +2,7 @@ package human
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ func TestTimeParse(t *testing.T) {
 		in  string
 		out Duration
 	}{
-		{in: "0s ago", out: 0},
+		{in: "now", out: 0},
 
 		{in: "1ns ago", out: -Nanosecond},
 		{in: "1µs ago", out: -Microsecond},
@@ -79,44 +80,50 @@ func TestTimeFormat(t *testing.T) {
 
 	for _, test := range []struct {
 		in  Duration
+		fmt string
 		out string
 	}{
-		{out: "0s ago", in: 0},
+		{fmt: "%v", out: "now", in: 0},
 
-		{out: "1ns ago", in: -Nanosecond},
-		{out: "1µs ago", in: -Microsecond},
-		{out: "1ms ago", in: -Millisecond},
-		{out: "1s ago", in: -Second},
-		{out: "1m ago", in: -Minute},
-		{out: "1h ago", in: -Hour},
+		{fmt: "%v", out: "1ns ago", in: -Nanosecond},
+		{fmt: "%v", out: "1µs ago", in: -Microsecond},
+		{fmt: "%v", out: "1ms ago", in: -Millisecond},
+		{fmt: "%v", out: "1s ago", in: -Second},
+		{fmt: "%v", out: "1m ago", in: -Minute},
+		{fmt: "%v", out: "1h ago", in: -Hour},
 
-		{out: "1d ago", in: -24 * Hour},
-		{out: "2d ago", in: -48 * Hour},
-		{out: "1w ago", in: -7 * 24 * Hour},
-		{out: "2w ago", in: -14 * 24 * Hour},
-		{out: "1mo ago", in: -33 * 24 * Hour},
-		{out: "2mo ago", in: -66 * 24 * Hour},
-		{out: "1y ago", in: -400 * 24 * Hour},
-		{out: "2y ago", in: -800 * 24 * Hour},
+		{fmt: "%v", out: "1d ago", in: -24 * Hour},
+		{fmt: "%v", out: "2d ago", in: -48 * Hour},
+		{fmt: "%v", out: "1w ago", in: -7 * 24 * Hour},
+		{fmt: "%v", out: "2w ago", in: -14 * 24 * Hour},
+		{fmt: "%v", out: "1mo ago", in: -33 * 24 * Hour},
+		{fmt: "%v", out: "2mo ago", in: -66 * 24 * Hour},
+		{fmt: "%v", out: "1y ago", in: -400 * 24 * Hour},
+		{fmt: "%v", out: "2y ago", in: -800 * 24 * Hour},
 
-		{out: "1ns later", in: Nanosecond},
-		{out: "1µs later", in: Microsecond},
-		{out: "1ms later", in: Millisecond},
-		{out: "1s later", in: Second},
-		{out: "1m later", in: Minute},
-		{out: "1h later", in: Hour},
+		{fmt: "%v", out: "1ns later", in: Nanosecond},
+		{fmt: "%v", out: "1µs later", in: Microsecond},
+		{fmt: "%v", out: "1ms later", in: Millisecond},
+		{fmt: "%v", out: "1s later", in: Second},
+		{fmt: "%v", out: "1m later", in: Minute},
+		{fmt: "%v", out: "1h later", in: Hour},
 
-		{out: "1d later", in: 24 * Hour},
-		{out: "2d later", in: 48 * Hour},
-		{out: "1w later", in: 7 * 24 * Hour},
-		{out: "2w later", in: 14 * 24 * Hour},
-		{out: "1mo later", in: 33 * 24 * Hour},
-		{out: "2mo later", in: 66 * 24 * Hour},
-		{out: "1y later", in: 400 * 24 * Hour},
-		{out: "2y later", in: 800 * 24 * Hour},
+		{fmt: "%v", out: "1d later", in: 24 * Hour},
+		{fmt: "%v", out: "2d later", in: 48 * Hour},
+		{fmt: "%v", out: "1w later", in: 7 * 24 * Hour},
+		{fmt: "%v", out: "2w later", in: 14 * 24 * Hour},
+		{fmt: "%v", out: "1mo later", in: 33 * 24 * Hour},
+		{fmt: "%v", out: "2mo later", in: 66 * 24 * Hour},
+		{fmt: "%v", out: "1y later", in: 400 * 24 * Hour},
+		{fmt: "%v", out: "2y later", in: 800 * 24 * Hour},
+
+		{fmt: "%v", out: "1m30s later", in: 1*Minute + 30*Second},
+		{fmt: "%+.1v", out: "2 hours later", in: 2*Hour + 1*Minute + 30*Second},
+		{fmt: "%+.2v", out: "2 hours 1 minute later", in: 2*Hour + 1*Minute + 30*Second},
+		{fmt: "%+.3v", out: "2 hours 1 minute 30 seconds later", in: 2*Hour + 1*Minute + 30*Second},
 	} {
 		t.Run(test.out, func(t *testing.T) {
-			if s := Time(now.Add(time.Duration(test.in))).Text(now); s != test.out {
+			if s := fmt.Sprintf(test.fmt, Time(now.Add(time.Duration(test.in))).Formatter(now)); s != test.out {
 				t.Error("time string mismatch:", s, "!=", test.out)
 			}
 		})


### PR DESCRIPTION
Follow up to #12, I was looking for a way to support more output formats for durations, including choosing between abbreviated and full representations (e.g. `1m30s` vs `1 minute 30 seconds`).

I landed on implementing the `fmt.Formatter` interface on types of the package to support various formats. For durations, using `%v` prints the abbreviated form, while `%+v` will print full words.