### PR TITLE
allow nil context

### DIFF
--- a/command.go
+++ b/command.go
@@ -226,7 +226,7 @@ func (cmd *CommandFunc) Call(ctx context.Context, args, env []string) (int, erro
 	if cmd.context {
 		params = append(params, reflect.ValueOf(ctx))
 		x++
-	} else if ctx != context.TODO() {
+	} else if ctx != nil && ctx != context.TODO() {
 		panic("to use context, all commands must accept a context.Context as their first argument")
 	}
 


### PR DESCRIPTION
I ran into a case where I wanted to use lower-level interfaces of this package and had to pass a context despite not needing one, and the only option is to give `context.TODO()` which didn't really communicate the intent of the program since the use of "no context" was supposed to remain.

This PR modifies the code to accept a `nil` context to represent this case.