### PR TITLE
add support for decoding types implementing encoding.BinaryUnmarshaler

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -225,6 +226,24 @@ func ExampleCommand_textUnmarshaler() {
 	// Output:
 	//
 	// hello world
+}
+
+func ExampleCommand_binaryUnmarshaler() {
+	type config struct {
+		URL url.URL `flag:"--url" default:"http://localhost/"`
+	}
+
+	cmd := cli.Command(func(config config) {
+		fmt.Println(config.URL.String())
+	})
+
+	cli.Call(cmd)
+	cli.Call(cmd, "--url", "http://www.segment.com/")
+
+	// Output:
+	//
+	// http://localhost/
+	// http://www.segment.com/
 }
 
 func ExampleCommand_default() {

--- a/format.go
+++ b/format.go
@@ -106,7 +106,7 @@ func newTextFormat(w io.Writer) *textFormat {
 
 func (p *textFormat) Print(x interface{}) {
 	switch x.(type) {
-	case encoding.TextMarshaler, fmt.Formatter, fmt.Stringer, error:
+	case encoding.TextMarshaler, encoding.BinaryMarshaler, fmt.Formatter, fmt.Stringer, error:
 		p.print(x)
 		return
 	}
@@ -209,6 +209,9 @@ func (p *textFormat) format(f string, v interface{}) string {
 		// fmt.Sprintf below.
 	case encoding.TextMarshaler:
 		b, _ := m.MarshalText()
+		return string(b)
+	case encoding.BinaryMarshaler:
+		b, _ := m.MarshalBinary()
 		return string(b)
 	}
 	return fmt.Sprintf(f, v)


### PR DESCRIPTION
This PR adds support for decoding types implementing the `encoding.BinaryUnmarshaler` interface. I came across this use case when I tried to have a `url.URL` in a config struct.