### PR TITLE
feat(command-set): treat empty string as a default command

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -388,6 +388,37 @@ func ExampleCommandSet() {
 	// that
 }
 
+func ExampleCommandSet_default() {
+	help := cli.Command(func() {
+		fmt.Println("help")
+	})
+
+	this := cli.Command(func() {
+		fmt.Println("this")
+	})
+
+	that := cli.Command(func() {
+		fmt.Println("that")
+	})
+
+	cmd := cli.CommandSet{
+		"help": help,
+		"do": cli.CommandSet{
+			"":     this,
+			"that": that,
+		},
+	}
+
+	cli.Call(cmd, "help")
+	cli.Call(cmd, "do")
+	cli.Call(cmd, "do", "that")
+
+	// Output:
+	// help
+	// this
+	// that
+}
+
 func ExampleCommand_help() {
 	type config struct {
 		Path  string `flag:"--path"     help:"Path to some file" default:"file" env:"-"`

--- a/command.go
+++ b/command.go
@@ -512,18 +512,20 @@ func (cmds CommandSet) Call(ctx context.Context, args, env []string) (int, error
 		return 0, &Help{Cmd: cmds}
 	}
 
-	if len(args) == 0 {
-		return 1, &Usage{Cmd: cmds, Err: fmt.Errorf("missing command")}
+	var a string
+	var otherargs []string
+	if len(args) > 0 {
+		a = args[0]
+		otherargs = args[1:]
 	}
 
-	a := args[0]
 	c := cmds[a]
 
 	if c == nil {
 		return 1, &Usage{Cmd: cmds, Err: fmt.Errorf("unknown command: %q", a)}
 	}
 
-	return NamedCommand(a, c).Call(ctx, args[1:], env)
+	return NamedCommand(a, c).Call(ctx, otherargs, env)
 }
 
 // Format writes a human-redable representation of cmds to w, using v as the


### PR DESCRIPTION
This PR allows for a `CommandSet` to configure a default command to run via `""` which runs in the absence of further sub-commands. This allows use-cases where you may want a command to do a thing and allow sub-commands to perform a related operation.