### PR TITLE
allow options to be passed before sub commands

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -407,6 +407,44 @@ func ExampleCommandSet() {
 	// that
 }
 
+func ExampleCommandSet_option_before_command() {
+	type config struct {
+		String string `flag:"-f,--flag" default:"-"`
+	}
+
+	sub := cli.Command(func(config config) {
+		fmt.Println(config.String)
+	})
+
+	cmd := cli.CommandSet{
+		"sub": sub,
+	}
+
+	cli.Call(cmd, "-f=hello", "sub")
+
+	// Output:
+	// hello
+}
+
+func ExampleCommandSet_option_after_command() {
+	type config struct {
+		String string `flag:"-f,--flag" default:"-"`
+	}
+
+	sub := cli.Command(func(config config) {
+		fmt.Println(config.String)
+	})
+
+	cmd := cli.CommandSet{
+		"sub": sub,
+	}
+
+	cli.Call(cmd, "sub", "-f=hello")
+
+	// Output:
+	// hello
+}
+
 func ExampleCommand_help() {
 	type config struct {
 		Path  string `flag:"--path"     help:"Path to some file" default:"file" env:"-"`

--- a/command.go
+++ b/command.go
@@ -512,18 +512,33 @@ func (cmds CommandSet) Call(ctx context.Context, args, env []string) (int, error
 		return 0, &Help{Cmd: cmds}
 	}
 
-	if len(args) == 0 {
+	var a string
+	var c Function
+
+	for i, arg := range args {
+		if isCommandSeparator(arg) {
+			break
+		}
+		if isOption(arg) {
+			continue
+		}
+		a = arg
+		tmp := make([]string, 0, len(args)-1)
+		tmp = append(tmp, args[:i]...)
+		tmp = append(tmp, args[i+1:]...)
+		args = tmp
+		break
+	}
+
+	if a == "" {
 		return 1, &Usage{Cmd: cmds, Err: fmt.Errorf("missing command")}
 	}
 
-	a := args[0]
-	c := cmds[a]
-
-	if c == nil {
+	if c = cmds[a]; c == nil {
 		return 1, &Usage{Cmd: cmds, Err: fmt.Errorf("unknown command: %q", a)}
 	}
 
-	return NamedCommand(a, c).Call(ctx, args[1:], env)
+	return NamedCommand(a, c).Call(ctx, args, env)
 }
 
 // Format writes a human-redable representation of cmds to w, using v as the


### PR DESCRIPTION
This PR modifies `segmentio/cli` to allow options to be passed before command names. For example, both of these forms are now accepted (only the first one was before the change):

```
program question --answer 42
```

```
program --answer 42 question
```

This makes programs a bit more user friendly, especially when using multiple sub-commands, and matches the behavior of popular CLIs like kubectl.