### PR TITLE
relax constaint on positional arguments

### DIFF
--- a/command.go
+++ b/command.go
@@ -263,18 +263,17 @@ func (cmd *CommandFunc) Call(ctx context.Context, args, env []string) (int, erro
 				break
 			}
 
+			var value []string
 			if len(values) == 0 {
-				return 1, &Usage{
-					Cmd: cmd,
-					Err: fmt.Errorf("expected %d positional arguments but only %d were given", len(cmd.values), i-x),
-				}
+				value = []string{""}
+			} else {
+				value, values = values[:1], values[1:]
 			}
 
-			if err := cmd.values[i-x](v, values[:1]); err != nil {
+			if err := cmd.values[i-x](v, value); err != nil {
 				return 1, err
 			}
 			params = append(params, v)
-			values = values[1:]
 		}
 	}
 


### PR DESCRIPTION
I found this to make things harder rather than safer, often times positional arguments can have defaults (for example reading from stdin if no file is given as input), and forcing them to be present prevents the construction of such programs.