### PR TITLE
fix usage output of commands with context

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -470,6 +470,31 @@ func ExampleCommand_help() {
 	//       --path string  Path to some file (default: file)
 }
 
+func ExampleCommand_helpContext() {
+	type config struct {
+		Path  string `flag:"--path"     help:"Path to some file" default:"file" env:"-"`
+		Debug bool   `flag:"-d,--debug" help:"Enable debug mode"`
+	}
+
+	cmd := cli.CommandSet{
+		"do": cli.Command(func(ctx context.Context, config config) {
+			// ...
+		}),
+	}
+
+	cli.Err = os.Stdout
+	cli.CallContext(context.Background(), cmd, "do", "-h")
+
+	// Output:
+	// Usage:
+	//   do [options]
+	//
+	// Options:
+	//   -d, --debug        Enable debug mode
+	//   -h, --help         Show this help message
+	//       --path string  Path to some file (default: file)
+}
+
 func ExampleCommand_usage() {
 	type config struct {
 		Count int  `flag:"-n"         help:"Number of things"  default:"1"`

--- a/command.go
+++ b/command.go
@@ -345,13 +345,20 @@ func (cmd *CommandFunc) Format(w fmt.State, v rune) {
 			n--
 		}
 
-		for i := 1; i < n; i++ {
+		i := 1
+		if cmd.context {
+			i = 2
+		}
+
+		for i < n {
 			p := t.In(i)
 			fmt.Fprintf(w, " [%s]", typeNameOf(p))
 
 			if p.Kind() == reflect.Slice {
 				break
 			}
+
+			i++
 		}
 
 		if cmd.variadic {


### PR DESCRIPTION
Before the change, when commands accepted a `context.Context` as first argument, the usage output would look like this:
```
Usage:
  program [options] [config]
```
The repeated `[config]` is undesirable as it was mistakenly interpreted as a positional argument.