### PR TITLE
README: add example of how to provide usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,10 @@ import (
 )
 
 func main() {
-	one := cli.Command(func() {
+	type oneConfig struct {
+		_ struct{} `help:"Usage text for command one"`
+	}
+	one := cli.Command(func(cfg oneConfig) {
 		fmt.Println("1")
 	})
 


### PR DESCRIPTION
This wasn't obvious to me.