### PR TITLE
command: allow CommandSet to have short usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,17 @@ func main() {
 		fmt.Println("2")
 	})
 
-	three := cli.Command(func() {
-		fmt.Println("3")
-	})
+	three := cli.CommandSet{
+        "_": cli.CommandFunc{
+            Help: "Usage text for the command three",
+        },
+        "four": cli.Command(func() {
+            fmt.Println("4")
+        }),
+        "five": cli.Command(func() {
+            fmt.Println("4")
+        }),
+	}
 
 	cli.Exec(cli.CommandSet{
 		"one":   one,
@@ -240,13 +248,12 @@ func main() {
 ```
 ```
 $ ./example5 --help
-
 Usage:
   example5 [command] [-h] [--help] ...
 
 Commands:
-  one
-  three
+  one    Usage text for command one
+  three  Usage text for the 'three' command
   two
 
 Options:

--- a/cli_test.go
+++ b/cli_test.go
@@ -407,6 +407,45 @@ func ExampleCommandSet() {
 	// that
 }
 
+func ExampleCommandSet_usage_text() {
+	help := cli.Command(func() {
+		fmt.Println("help")
+	})
+
+	doc := cli.Command(func() {
+		fmt.Println("doc")
+	})
+
+	cover := cli.Command(func() {
+		fmt.Println("cover")
+	})
+
+	cmd := cli.CommandSet{
+		"help": help,
+		"tool": cli.CommandSet{
+			"_": &cli.CommandFunc{
+				Help: "run specified go tool",
+			},
+			"cover": cover,
+			"doc":   doc,
+		},
+	}
+
+	cli.Err = os.Stdout
+	cli.Call(cmd, "--help")
+
+	// Output:
+	// Usage:
+	//   [command] [-h] [--help] ...
+	//
+	// Commands:
+	//   help
+	//   tool  run specified go tool
+	//
+	// Options:
+	//   -h, --help  Show this help message
+}
+
 func ExampleCommandSet_option_before_command() {
 	type config struct {
 		String string `flag:"-f,--flag" default:"-"`

--- a/examples/example5.go
+++ b/examples/example5.go
@@ -7,7 +7,10 @@ import (
 )
 
 func main() {
-	one := cli.Command(func() {
+	type oneConfig struct {
+		_ struct{} `help:"Usage text for command one"`
+	}
+	one := cli.Command(func(cfg oneConfig) {
 		fmt.Println("1")
 	})
 
@@ -15,9 +18,17 @@ func main() {
 		fmt.Println("2")
 	})
 
-	three := cli.Command(func() {
-		fmt.Println("3")
-	})
+	three := cli.CommandSet{
+		"_": &cli.CommandFunc{
+			Help: "Usage text for the 'three' command",
+		},
+		"four": cli.Command(func() {
+			fmt.Println("4")
+		}),
+		"five": cli.Command(func() {
+			fmt.Println("4")
+		}),
+	}
 
 	cli.Exec(cli.CommandSet{
 		"one":   one,


### PR DESCRIPTION
Show an example of how to provide usage text if you have nested
CommandSets - setting a key to "_" with help text will print that help
text if the user asks for it for the parent command.