### PR TITLE
cli_test: fix tests

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -172,10 +172,10 @@ func ExampleCommand_time() {
 	})
 
 	cli.Call(cmd)
-	cli.Call(cmd, "-f=Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(cmd, "--flag=Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(cmd, "-f", "Mon, 02 Jan 2006 15:04:05 PST")
-	cli.Call(cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 PST")
+	cli.Call(cmd, "-f=Mon, 02 Jan 2006 15:04:05 UTC")
+	cli.Call(cmd, "--flag=Mon, 02 Jan 2006 15:04:05 UTC")
+	cli.Call(cmd, "-f", "Mon, 02 Jan 2006 15:04:05 UTC")
+	cli.Call(cmd, "--flag", "Mon, 02 Jan 2006 15:04:05 UTC")
 
 	// Output:
 	//-62135596800


### PR DESCRIPTION
Using UTC means that we don't have any time zone or local time issues,
so we should always get the same number back out.