### PR TITLE
cli: better formatting for Help struct

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -114,14 +114,33 @@ type Help struct {
 	Cmd Function
 }
 
+// Fallback for unimplemented fmt verbs
+type fmtHelp struct{ cmd Function }
+
 // Error satisfies the error interface.
 func (h *Help) Error() string { return fmt.Sprintf("help: %s", h.Cmd) }
 
 // Format satisfies the fmt.Formatter interface, print the help message for the
 // command carried by h.
-func (h *Help) Format(w fmt.State, _ rune) {
-	printUsage(w, h.Cmd)
-	printHelp(w, h.Cmd)
+func (h *Help) Format(w fmt.State, v rune) {
+	switch v {
+	case 's':
+		printUsage(w, h.Cmd)
+		printHelp(w, h.Cmd)
+	case 'v':
+		if w.Flag('#') {
+			io.WriteString(w, "cli.Help{")
+			fmt.Fprintf(w, "%#v", h.Cmd)
+			io.WriteString(w, "}")
+			return
+		}
+		printUsage(w, h.Cmd)
+		printHelp(w, h.Cmd)
+	default:
+		// fall back to default struct formatter. TODO this does not handle
+		// flags
+		fmt.Fprintf(w, "%"+string(v), fmtHelp{h.Cmd})
+	}
 }
 
 // Usage values are returned by commands to indicate that the combination of

--- a/cli_test.go
+++ b/cli_test.go
@@ -726,3 +726,13 @@ func ExampleCommand_embedded_struct() {
 	// a B
 	// A B
 }
+
+func TestHelpFormat(t *testing.T) {
+	var c cli.Help
+	got := fmt.Sprintf("%#v", c)
+	if want := "cli.Help{Cmd:cli.Function(nil)}"; got != want {
+		// this is not going to be the most useful when it's also got format
+		// strings, but probably better than nothing...
+		t.Errorf("Sprintf(%%#v, cli.Help{}): got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Previously, we'd return the help text no matter what format arguments
were passed to Help.Format(). This made it hard to troubleshoot what
was happening, why we were printing out the same text twice...

This is not a perfect implementation of Help string formatting but it
should improve things slightly. There is a little bit of momentum in
the standard library to standardize improvements to fmt.Formatter and
fmt.State, that we should implement when they are available.