### PR TITLE
cli: print errors to Err

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,7 @@ jobs:
         - 1.15
         - 1.16
         - 1.17
+        - 1.18
 
     runs-on: ubuntu-latest
 

--- a/cli.go
+++ b/cli.go
@@ -86,7 +86,8 @@ func CallContext(ctx context.Context, cmd Function, args ...string) int {
 		fmt.Fprintln(Err, err)
 	default:
 		if err != nil {
-			log.Print(err)
+			errorLogger := log.New(Err, "", log.LstdFlags)
+			errorLogger.Print(err)
 			code = 1
 		}
 	}


### PR DESCRIPTION
If cmd.Call() returns an error, write it to Err instead of to
os.Stderr. This makes it possible to catch the error output in a test
and make assertions about it.