### PR TITLE
[CONFIG-241] upgrade gopkg.in/yaml.v3 to v3.0.1 which has a fix for CVE-2022-28948

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -27,7 +27,7 @@ type Function interface {
 // Exec delegate the program execution to cmd, then exits with the code returned
 // by the function call.
 //
-// A typeical use case is for Exec to be the last statement of the main function
+// A typical use case is for Exec to be the last statement of the main function
 // of a program:
 //
 //	func main() {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/segmentio/cli
 
 go 1.17
 
-require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Part of fixing [CONFIG-241](https://segment.atlassian.net/browse/CONFIG-241).

A snyk run for a project using the flagon library uncovered that the gopkg.in/yaml.v3 library we are using in many places has a vulnerability:
* https://app.snyk.io/org/segment-pro/project/bc624be5-ab96-4c12-9587-cf1c42cedb32/pr-check/53ca82ed-84ea-4c16-9443-cedf2af0ea15

Upgrade the library to v3.0.1:

```
go get gopkg.in/yaml.v3@v3.0.1
```

# Testing

Testing completed successfully locally by running the example code.

Leveraged the example code that sits in this repo.  Took example code from the snyk vulnerabilty DB entry:
* https://security.snyk.io/vuln/SNYK-GOLANG-GOPKGINYAMLV3-2841557

```
package main import ( "gopkg.in/yaml.v3" ) func main() { var t interface{} yaml.Unmarshal([]byte("0: [:!00 \xef"), &t) }
```

And put that code into `example1.go`:

```
diff --git examples/example1.go examples/example1.go
index 6aba8a0..2ed8114 100644
--- examples/example1.go
+++ examples/example1.go
@@ -4,9 +4,13 @@ import (
 	"fmt"

 	"github.com/segmentio/cli"
+	"gopkg.in/yaml.v3"
 )

 func main() {
+	var t interface{}
+	yaml.Unmarshal([]byte("0: [:!00 \xef"), &t)
+
 	type config struct {
 		Name string `flag:"-n,--name" help:"Someone's name" default:"Luke"`
 	}
```

Then ran the code:

```
✗ go run examples/example1.go
panic: internal error: attempted to parse unknown event (please report): none [recovered]
	panic: internal error: attempted to parse unknown event (please report): none

goroutine 1 [running]:
gopkg.in/yaml%2ev3.handleErr(0xc00013dee8)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/yaml.go:294 +0x6d
panic({0x11045c0, 0xc00010c360})
	/usr/local/Cellar/go/1.19.2/libexec/src/runtime/panic.go:884 +0x212
gopkg.in/yaml%2ev3.(*parser).parse(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:163 +0x199
gopkg.in/yaml%2ev3.(*parser).parseChild(...)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:194
gopkg.in/yaml%2ev3.(*parser).sequence(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:259 +0x128
gopkg.in/yaml%2ev3.(*parser).parse(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:154 +0xeb
gopkg.in/yaml%2ev3.(*parser).parseChild(0xc00015a000?, 0xc0001303c0)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:194 +0x25
gopkg.in/yaml%2ev3.(*parser).mapping(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:285 +0x1d7
gopkg.in/yaml%2ev3.(*parser).parse(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:152 +0x105
gopkg.in/yaml%2ev3.(*parser).parseChild(...)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:194
gopkg.in/yaml%2ev3.(*parser).document(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:203 +0x85
gopkg.in/yaml%2ev3.(*parser).parse(0xc00015a000)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/decode.go:156 +0xae
gopkg.in/yaml%2ev3.unmarshal({0xc000124590, 0xa, 0xa}, {0x11002c0?, 0xc00010c350}, 0x0?)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/yaml.go:161 +0x325
gopkg.in/yaml%2ev3.Unmarshal(...)
	/Users/erik.weathers/dev/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/yaml.go:89
main.main()
	/Users/erik.weathers/dev/src/github.com/segmentio/cli/examples/example1.go:12 +0x69
exit status 2
```

This showed that the problem does indeed exist here.

After upgrading the library I reran the code and it no longer crashes, and it produces the same output as it did before the problematic YAML unmarshalling was added:

```
✗ go run examples/example1.go
hello Luke!
```