### PR TITLE
human: fix parsing issues

### DIFF
--- a/human/duration.go
+++ b/human/duration.go
@@ -60,12 +60,18 @@ func ParseDurationUntil(s string, now time.Time) (Duration, error) {
 	}
 
 	for len(s) != 0 {
+		// parse the next number
+
 		n, r, err := parseFloat(s)
 		if err != nil {
 			return 0, fmt.Errorf("malformed duration: %s: %w", input, err)
 		}
 		s = r
 
+		// parse "weeks", "days", "h", etc.
+		if s == "" {
+			return 0, fmt.Errorf("please include a unit ('weeks', 'h', 'm') in addition to the value (%f)", n)
+		}
 		v, r, err := parseDuration(s, n, now)
 		if err != nil {
 			return 0, fmt.Errorf("malformed duration: %s: %w", input, err)
@@ -176,9 +182,8 @@ func (d Duration) GoString() string {
 //
 // The 's' and 'v' formatting verbs also interpret the options:
 //
-//	+	outputs full names of the time units instead of abbreviations
-//	.	followed by a digit to limit the precision of the output
-//
+//   - outputs full names of the time units instead of abbreviations
+//     .	followed by a digit to limit the precision of the output
 func (d Duration) Format(w fmt.State, v rune) {
 	d.formatUntil(w, v, time.Now())
 }

--- a/human/duration_test.go
+++ b/human/duration_test.go
@@ -54,6 +54,16 @@ func TestDurationParse(t *testing.T) {
 	}
 }
 
+func TestDurationError(t *testing.T) {
+	_, err := ParseDuration("10")
+	if err == nil {
+		t.Fatal(err, "ParseDuration(10), expected error, got nil")
+	}
+	if want := "please include a unit ('weeks', 'h', 'm') in addition to the value (10.000000)"; err.Error() != want {
+		t.Errorf(`ParseDuration("10"), got %q, want %q`, err.Error(), want)
+	}
+}
+
 func TestDurationFormat(t *testing.T) {
 	for _, test := range []struct {
 		in  Duration

--- a/human/human.go
+++ b/human/human.go
@@ -25,7 +25,6 @@
 //		BufferSize:  64 * KiB,
 //		RateLimit:   20 * PerSecond,
 //	}
-//
 package human
 
 import (
@@ -62,10 +61,15 @@ func countPrefixFunc(s string, f func(rune) bool) int {
 	var i int
 	var r rune
 
+	terminated := false
 	for i, r = range s {
 		if !f(r) {
+			terminated = true
 			break
 		}
+	}
+	if !terminated {
+		return i + 1
 	}
 
 	return i
@@ -86,7 +90,7 @@ func parseNextNumber(s string) (string, string) {
 	i += countPrefixFunc(s[i:], isSign) // - or +
 	i += countPrefixFunc(s[i:], unicode.IsDigit)
 
-	// decimal part
+	// Count all of the digits after the decimal (if one exists)
 	if hasPrefixFunc(s[i:], isDot) {
 		i++ // .
 		i += countPrefixFunc(s[i:], unicode.IsDigit)
@@ -116,6 +120,8 @@ func parseNextToken(s string) (string, string) {
 	return s, ""
 }
 
+// parseFloat tries to parse a number at the beginning of s, and returns the
+// remainder as well as any error that occurs.
 func parseFloat(s string) (float64, string, error) {
 	s, r := parseNextNumber(s)
 	f, err := strconv.ParseFloat(s, 64)

--- a/human/human_test.go
+++ b/human/human_test.go
@@ -1,6 +1,8 @@
 package human
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestParseNextToken(t *testing.T) {
 	for _, test := range []struct {
@@ -34,5 +36,16 @@ func TestParseNextToken(t *testing.T) {
 				t.Errorf("tail mismatch: %q != %q", tail, test.tail)
 			}
 		})
+	}
+}
+
+func TestParseFloat(t *testing.T) {
+	in := "10"
+	n, _, err := parseFloat(in)
+	if err != nil {
+		t.Fatalf("parseFloat(%q): got %q, want nil", in, err)
+	}
+	if want := float64(10); n != want {
+		t.Fatalf("parseFloat(%q): got %f, want %f", in, n, want)
 	}
 }


### PR DESCRIPTION
The existing implementation of countPrefix had an off-by-one error
where if the prefix was not found, we would return (len - 1)
instead of returning (len), which led to nonsensical results like
parseFloat("98") returning 9 instead of 98.

Fix that error and also fix duration parsing to return a better error
message if you don't include a unit in the provided duration.