### PR TITLE
cli,command: fix error representation

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -66,7 +66,6 @@ func ExecContext(ctx context.Context, cmd Function) {
 //		// Output:
 //		// ...
 //	}
-//
 func Call(cmd Function, args ...string) int {
 	return CallContext(context.TODO(), cmd, args...)
 }
@@ -156,10 +155,22 @@ func (u *Usage) Error() string { return fmt.Sprintf("usage: %s: %s", u.Cmd, u.Er
 
 // Format satisfies the fmt.Formatter interface, print the usage message for the
 // command carried by u.
-func (u *Usage) Format(w fmt.State, _ rune) {
-	printUsage(w, u.Cmd)
-	printHelp(w, u.Cmd)
-	printError(w, u.Err)
+func (u *Usage) Format(w fmt.State, v rune) {
+	if v == 'v' && w.Flag('#') {
+		io.WriteString(w, "cli.Usage{")
+		fmt.Fprintf(w, "Cmd: %#v, ", u.Cmd)
+		fmt.Fprintf(w, "Err: %#v", u.Err)
+		io.WriteString(w, "}")
+		return
+	}
+	// TODO: better detection/printing based on the requested format string.
+	if u.Cmd != nil {
+		printUsage(w, u.Cmd)
+		printHelp(w, u.Cmd)
+	}
+	if u.Err != nil {
+		printError(w, u.Err)
+	}
 }
 
 // Unwrap satisfies the errors wrapper interface.

--- a/cli_test.go
+++ b/cli_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -750,5 +751,23 @@ func TestHelpFormat(t *testing.T) {
 		// this is not going to be the most useful when it's also got format
 		// strings, but probably better than nothing...
 		t.Errorf("Sprintf(%%#v, cli.Help{}): got %q, want %q", got, want)
+	}
+}
+
+func TestUsage(t *testing.T) {
+	u := cli.Usage{Err: errors.New("this is an error")}
+	got := fmt.Sprintf("%s", &u)
+	want := "\nError:\n  this is an error\n\n"
+	if got != want {
+		t.Errorf("Sprintf(%%#v, got %q, want %q", got, want)
+	}
+}
+
+func TestUsageFmt(t *testing.T) {
+	u := cli.Usage{Err: errors.New("this is an error")}
+	got := fmt.Sprintf("%#v", &u)
+	want := `cli.Usage{Cmd: <nil>, Err: &errors.errorString{s:"this is an error"}}`
+	if got != want {
+		t.Errorf("Sprintf(%%#v, got %q, want %q", got, want)
 	}
 }

--- a/command.go
+++ b/command.go
@@ -277,6 +277,12 @@ func (cmd *CommandFunc) Call(ctx context.Context, args, env []string) (int, erro
 			// Configuration options are decoded into the first function parameter.
 			v := reflect.New(t.In(x)).Elem()
 			if err := cmd.options.decode(v, options); err != nil {
+				if uerr, ok := err.(*Usage); ok {
+					uerr.Cmd = cmd
+				}
+				if herr, ok := err.(*Help); ok {
+					herr.Cmd = cmd
+				}
 				return 1, err
 			}
 			params = append(params, v)
@@ -370,7 +376,6 @@ func (cmd *CommandFunc) Call(ctx context.Context, args, env []string) (int, erro
 //	%s	outputs the usage information of the command
 //	%v	outputs the full description of the command
 //	%x	outputs the help message of the command
-//
 func (cmd *CommandFunc) Format(w fmt.State, v rune) {
 	switch v {
 	case 's': // usage
@@ -542,7 +547,6 @@ func isLongFlag(s string) bool  { return strings.HasPrefix(s, "--") }
 //	$ program top sub-1
 //
 //	$ program top sub-2
-//
 type CommandSet map[string]Function
 
 // Call dispatches the given arguments and environment variables to the

--- a/command_test.go
+++ b/command_test.go
@@ -1,6 +1,13 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/segmentio/cli/human"
+)
 
 func TestSimilarEnough(t *testing.T) {
 	tests := []struct {
@@ -24,5 +31,38 @@ func TestSimilarEnough(t *testing.T) {
 			t.Errorf("similarEnough(%q, %q, %d): got %t, want %t", tt.input,
 				tt.cmd, lvn, got, tt.want)
 		}
+	}
+}
+
+// The individual struct decoders don't have access to the entire command, but
+// it should be assigned by the parent *CommandFunc after the error is caught.
+func TestStructDecoderFail(t *testing.T) {
+	var b bytes.Buffer
+	Err = &b
+	defer func() {
+		Err = os.Stderr
+	}()
+	type config struct {
+		Duration human.Duration `flag:"--duration"`
+	}
+	cmd := Command(func(cfg config) {
+		fmt.Println(cfg.Duration)
+	})
+	Call(cmd, "--duration=10")
+	want := `
+Usage:
+  [options]
+
+Options:
+      --duration duration
+  -h, --help               Show this help message
+
+Error:
+  decoding "--duration": please include a unit ('weeks', 'h', 'm') in addition to the value (10.000000)
+
+
+`
+	if b.String() != want {
+		t.Errorf("Struct error: got %q, want %q", b.String(), want)
 	}
 }


### PR DESCRIPTION
If a parse error occurs on a command flag, catch and re-throw the
error with more context in the *CommandFunc.Call function. Otherwise
the only context you get is the failed flag, without a list of all of
the options or what they mean.

Also, only print out Cmd and Err if they are non-nil, otherwise you
get "Command: <nil>" in the output, which is very confusing.