### PR TITLE
fix: Allow "-" as an option value

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -8,7 +8,7 @@ import (
 type testStructType struct {
 	_        struct{} `help:"Greets someone from a galaxy far, far away"`
 	Name     string   `flag:"-n,--name" help:"Someone's name" default:"Luke"`
-  Surname  string   `flag:"-s, --surname, --last-name" help:"Someone's surname" default:"Skywalker"`
+	Surname  string   `flag:"-s, --surname, --last-name" help:"Someone's surname" default:"Skywalker"`
 	Planet   string   `flag:"-p,--planet" help:"Someone's home planet" env:"-" default:"-"`
 	darkside bool     `flag:"--dark,--dark-side" help:"True if friend of the Sith"`
 }

--- a/parse.go
+++ b/parse.go
@@ -81,7 +81,7 @@ func (p parser) parseCommandLine(args []string) (options map[string][]string, va
 }
 
 func isOption(s string) bool {
-	return len(s) > 0 && s[0] == '-'
+	return len(s) > 1 && s[0] == '-'
 }
 
 func isCommandSeparator(s string) bool {

--- a/parse_test.go
+++ b/parse_test.go
@@ -10,11 +10,12 @@ func TestParseCommandLine(t *testing.T) {
 		options: map[string]option{
 			"-A":     {boolean: false},
 			"--bool": {boolean: true},
+			"-n":     {boolean: false},
 		},
 	}
 
 	args := []string{
-		"-A=1", "-A", "2", "--bool", "a", "b", "c", "--", "command", "line",
+		"-A=1", "-A", "2", "--bool", "-A", "-", "a", "b", "c", "--", "command", "line",
 	}
 
 	options, values, command, err := parser.parseCommandLine(args)
@@ -23,7 +24,7 @@ func TestParseCommandLine(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(options, map[string][]string{
-		"-A":     {"1", "2"},
+		"-A":     {"1", "2", "-"},
 		"--bool": {"true"},
 	}) {
 		t.Error("options mismatch:", options)


### PR DESCRIPTION
Parsing is adjusted so that a single "-" as a parsed command line token
is no longer interpreted as an option. This allows the string to be a
valid option value, such as for the common convention of using it to
represent standard input, e.g., "-f -".
